### PR TITLE
Fix date parsing to avoid timezone issues

### DIFF
--- a/client/src/lib/dateUtils.ts
+++ b/client/src/lib/dateUtils.ts
@@ -6,7 +6,12 @@ import { DATE_FORMATS } from "./constants";
  */
 export function formatDateForDisplay(date: Date | string | undefined): string {
   if (!date) return "";
-  const dateObj = typeof date === "string" ? new Date(date) : date;
+  let dateObj: Date;
+  if (typeof date === "string") {
+    dateObj = parse(date, DATE_FORMATS.INPUT, new Date());
+  } else {
+    dateObj = date;
+  }
   if (!isValid(dateObj)) return "";
   return format(dateObj, DATE_FORMATS.DISPLAY);
 }
@@ -16,7 +21,12 @@ export function formatDateForDisplay(date: Date | string | undefined): string {
  */
 export function formatDateWithWeekday(date: Date | string | undefined): string {
   if (!date) return "";
-  const dateObj = typeof date === "string" ? new Date(date) : date;
+  let dateObj: Date;
+  if (typeof date === "string") {
+    dateObj = parse(date, DATE_FORMATS.INPUT, new Date());
+  } else {
+    dateObj = date;
+  }
   if (!isValid(dateObj)) return "";
   return format(dateObj, DATE_FORMATS.DISPLAY_WITH_WEEKDAY);
 }
@@ -26,7 +36,12 @@ export function formatDateWithWeekday(date: Date | string | undefined): string {
  */
 export function formatDateForInput(date: Date | string | undefined): string {
   if (!date) return "";
-  const dateObj = typeof date === "string" ? new Date(date) : date;
+  let dateObj: Date;
+  if (typeof date === "string") {
+    dateObj = parse(date, DATE_FORMATS.INPUT, new Date());
+  } else {
+    dateObj = date;
+  }
   if (!isValid(dateObj)) return "";
   return format(dateObj, DATE_FORMATS.INPUT);
 }
@@ -35,7 +50,12 @@ export function formatDateForInput(date: Date | string | undefined): string {
  * Format a date for API requests
  */
 export function formatDateForAPI(date: Date | string): string {
-  const dateObj = typeof date === "string" ? new Date(date) : date;
+  let dateObj: Date;
+  if (typeof date === "string") {
+    dateObj = parse(date, DATE_FORMATS.INPUT, new Date());
+  } else {
+    dateObj = date;
+  }
   if (!isValid(dateObj)) throw new Error("Invalid date");
   return format(dateObj, DATE_FORMATS.API);
 }
@@ -73,7 +93,12 @@ export function parseInputDate(dateString: string): Date | null {
  */
 export function formatDateDisplay(date: Date | string | undefined): string {
   if (!date) return "";
-  const dateObj = typeof date === "string" ? new Date(date) : date;
+  let dateObj: Date;
+  if (typeof date === "string") {
+    dateObj = parse(date, DATE_FORMATS.INPUT, new Date());
+  } else {
+    dateObj = date;
+  }
   if (!isValid(dateObj)) return "";
   return format(dateObj, "MM/dd/yyyy");
 }

--- a/client/src/pages/WeeklyPayroll.tsx
+++ b/client/src/pages/WeeklyPayroll.tsx
@@ -74,7 +74,7 @@ const WeeklyPayroll: React.FC = () => {
   // Initialize selected date when payroll loads or changes
   useEffect(() => {
     if (currentPayroll) {
-      setSelectedDate(formatDateForInput(new Date(currentPayroll.weekEndingDate)));
+      setSelectedDate(formatDateForInput(currentPayroll.weekEndingDate));
     }
   }, [currentPayroll]);
 
@@ -256,7 +256,7 @@ const WeeklyPayroll: React.FC = () => {
                   </button>
                 )}
               </div>
-              {selectedDate !== (currentPayroll ? formatDateForInput(new Date(currentPayroll.weekEndingDate)) : "") && (
+              {selectedDate !== (currentPayroll ? formatDateForInput(currentPayroll.weekEndingDate) : "") && (
                 <p className="text-xs text-amber-600">
                   Date change not saved. Click Update to apply.
                 </p>


### PR DESCRIPTION
## Summary
- parse server-provided date strings using `date-fns` instead of `new Date`
- update WeeklyPayroll to use new helpers when initializing and comparing dates

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*