### PR TITLE
Add basic user authentication

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,6 @@
 import { Switch, Route } from "wouter";
-import { queryClient } from "./lib/queryClient";
-import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient, getQueryFn } from "./lib/queryClient";
+import { QueryClientProvider, useQuery } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import NotFound from "@/pages/not-found";
@@ -9,8 +9,23 @@ import Dashboard from "./pages/Dashboard";
 import Plumbers from "./pages/Plumbers";
 import WeeklyPayroll from "./pages/WeeklyPayroll";
 import Reports from "./pages/Reports";
+import Login from "./pages/Login";
+import Register from "./pages/Register";
 
 function Router() {
+  const { data: user, isLoading } = useQuery(["/api/me"], getQueryFn({ on401: "returnNull" }));
+
+  if (isLoading) return null;
+
+  if (!user) {
+    return (
+      <Switch>
+        <Route path="/register" component={Register} />
+        <Route component={Login} />
+      </Switch>
+    );
+  }
+
   return (
     <Layout>
       <Switch>

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useLocation } from "wouter";
+import { apiRequest } from "@/lib/queryClient";
 
 interface HeaderProps {
   onOpenSidebar: () => void;
@@ -7,6 +8,11 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ onOpenSidebar }) => {
   const [location] = useLocation();
+
+  const handleLogout = async () => {
+    await apiRequest("POST", "/api/logout");
+    window.location.href = "/";
+  };
   
   // Get title based on current path
   const getTitle = () => {
@@ -43,12 +49,10 @@ const Header: React.FC<HeaderProps> = ({ onOpenSidebar }) => {
             <span>Help</span>
           </button>
           
-          <div className="flex items-center">
-            <span className="hidden md:block text-sm font-medium mr-2">Admin</span>
-            <button className="flex items-center justify-center w-8 h-8 rounded-full bg-blue-600 text-white">
-              <span className="material-icons text-sm">person</span>
-            </button>
-          </div>
+          <button onClick={handleLogout} className="btn btn-secondary px-3 py-1 text-xs flex items-center gap-1">
+            <span className="material-icons text-sm">logout</span>
+            <span>Logout</span>
+          </button>
         </div>
       </div>
     </header>

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { useLocation } from "wouter";
+import { apiRequest } from "@/lib/queryClient";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function Login() {
+  const [, navigate] = useLocation();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await apiRequest("POST", "/api/login", { username, password });
+      navigate("/");
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-medium text-center">Login</h1>
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <Input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <Input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <Button type="submit" className="w-full">Login</Button>
+        <div className="text-center text-sm">
+          <a href="/register" className="text-blue-600 hover:underline">Create account</a>
+        </div>
+      </form>
+    </div>
+  );
+}
+

--- a/client/src/pages/Register.tsx
+++ b/client/src/pages/Register.tsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import { useLocation } from "wouter";
+import { apiRequest } from "@/lib/queryClient";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+export default function Register() {
+  const [, navigate] = useLocation();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await apiRequest("POST", "/api/register", { username, passwordHash: password });
+      navigate("/");
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen p-4">
+      <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
+        <h1 className="text-2xl font-medium text-center">Create Account</h1>
+        {error && <div className="text-red-600 text-sm">{error}</div>}
+        <Input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <Input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
+        <Button type="submit" className="w-full">Register</Button>
+        <div className="text-center text-sm">
+          <a href="/login" className="text-blue-600 hover:underline">Back to login</a>
+        </div>
+      </form>
+    </div>
+  );
+}
+

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,0 +1,15 @@
+import crypto from "crypto";
+
+export function hashPassword(password: string): string {
+  const salt = crypto.randomBytes(16).toString("hex");
+  const hash = crypto.scryptSync(password, salt, 64).toString("hex");
+  return `${salt}:${hash}`;
+}
+
+export function verifyPassword(password: string, stored: string): boolean {
+  const [salt, hash] = stored.split(":");
+  if (!salt || !hash) return false;
+  const testHash = crypto.scryptSync(password, salt, 64).toString("hex");
+  return crypto.timingSafeEqual(Buffer.from(hash, "hex"), Buffer.from(testHash, "hex"));
+}
+

--- a/server/pgStorage.ts
+++ b/server/pgStorage.ts
@@ -1,9 +1,10 @@
 import { eq, and, desc } from "drizzle-orm";
 import { db } from "./db";
-import { 
+import {
   plumbers, type Plumber, type InsertPlumber, type UpdatePlumber,
   jobs, type Job, type InsertJob, type UpdateJob,
   payrolls, type Payroll, type InsertPayroll, type UpdatePayroll,
+  users, type User, type InsertUser,
   type JobWithPlumber, type PayrollSummary
 } from "@shared/schema";
 import { IStorage } from "./storage";
@@ -210,5 +211,21 @@ export class PgStorage implements IStorage {
     }
     
     return Array.from(plumberSummaryMap.values());
+  }
+
+  // User operations
+  async createUser(user: InsertUser): Promise<User> {
+    const results = await db.insert(users).values(user).returning();
+    return results[0];
+  }
+
+  async getUserByUsername(username: string): Promise<User | undefined> {
+    const results = await db.select().from(users).where(eq(users.username, username));
+    return results.length ? results[0] : undefined;
+  }
+
+  async getUserById(id: number): Promise<User | undefined> {
+    const results = await db.select().from(users).where(eq(users.id, id));
+    return results.length ? results[0] : undefined;
   }
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,7 +1,8 @@
-import { 
+import {
   plumbers, type Plumber, type InsertPlumber, type UpdatePlumber,
   jobs, type Job, type InsertJob, type UpdateJob,
   payrolls, type Payroll, type InsertPayroll, type UpdatePayroll,
+  users, type User, type InsertUser,
   type JobWithPlumber, type PayrollSummary
 } from "@shared/schema";
 
@@ -36,23 +37,32 @@ export interface IStorage {
   
   // Summary operations
   getPayrollSummary(payrollId: number): Promise<PayrollSummary[]>;
+
+  // User operations
+  createUser(user: InsertUser): Promise<User>;
+  getUserByUsername(username: string): Promise<User | undefined>;
+  getUserById(id: number): Promise<User | undefined>;
 }
 
 export class MemStorage implements IStorage {
   private plumbers: Map<number, Plumber>;
   private jobs: Map<number, Job>;
   private payrolls: Map<number, Payroll>;
+  private users: Map<number, User>;
   private plumberId: number;
   private jobId: number;
   private payrollId: number;
+  private userId: number;
 
   constructor() {
     this.plumbers = new Map();
     this.jobs = new Map();
     this.payrolls = new Map();
+    this.users = new Map();
     this.plumberId = 1;
     this.jobId = 1;
     this.payrollId = 1;
+    this.userId = 1;
     
     // Initialize with sample data for development
     this.initializeData();
@@ -263,6 +273,25 @@ export class MemStorage implements IStorage {
     }
     
     return Array.from(plumberSummaryMap.values());
+  }
+
+  // User operations
+  async createUser(user: InsertUser): Promise<User> {
+    const id = this.userId++;
+    const newUser: User = { ...user, id };
+    this.users.set(id, newUser);
+    return newUser;
+  }
+
+  async getUserByUsername(username: string): Promise<User | undefined> {
+    for (const u of this.users.values()) {
+      if (u.username === username) return u;
+    }
+    return undefined;
+  }
+
+  async getUserById(id: number): Promise<User | undefined> {
+    return this.users.get(id);
   }
 }
 

--- a/server/types.d.ts
+++ b/server/types.d.ts
@@ -1,0 +1,6 @@
+declare module "express-session" {
+  interface SessionData {
+    userId?: number;
+  }
+}
+

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -3,6 +3,21 @@ import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 import { sql } from "drizzle-orm";
 
+// User model
+export const users = pgTable("users", {
+  id: serial("id").primaryKey(),
+  username: text("username").notNull().unique(),
+  passwordHash: text("password_hash").notNull(),
+});
+
+export const insertUserSchema = createInsertSchema(users).pick({
+  username: true,
+  passwordHash: true,
+});
+
+export type InsertUser = z.infer<typeof insertUserSchema>;
+export type User = typeof users.$inferSelect;
+
 // Plumber model
 export const plumbers = pgTable("plumbers", {
   id: serial("id").primaryKey(),


### PR DESCRIPTION
## Summary
- add user table to shared schema
- implement user storage for memory and PostgreSQL
- add password hashing helpers and session support
- add login, registration, logout and /me API routes
- create Login and Register pages and update router
- add logout button in header

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*