### PR TITLE
Fix login, add password reset and user names

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import WeeklyPayroll from "./pages/WeeklyPayroll";
 import Reports from "./pages/Reports";
 import Login from "./pages/Login";
 import Register from "./pages/Register";
+import ForgotPassword from "./pages/ForgotPassword";
 
 function Router() {
   const { data: user, isLoading } = useQuery(["/api/me"], getQueryFn({ on401: "returnNull" }));
@@ -21,6 +22,7 @@ function Router() {
     return (
       <Switch>
         <Route path="/register" component={Register} />
+        <Route path="/forgot-password" component={ForgotPassword} />
         <Route component={Login} />
       </Switch>
     );

--- a/client/src/components/Header.tsx
+++ b/client/src/components/Header.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { useLocation } from "wouter";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest, getQueryFn } from "@/lib/queryClient";
+import { useQuery } from "@tanstack/react-query";
 
 interface HeaderProps {
   onOpenSidebar: () => void;
@@ -8,6 +9,7 @@ interface HeaderProps {
 
 const Header: React.FC<HeaderProps> = ({ onOpenSidebar }) => {
   const [location] = useLocation();
+  const { data: user } = useQuery(["/api/me"], getQueryFn({ on401: "throw" }));
 
   const handleLogout = async () => {
     await apiRequest("POST", "/api/logout");
@@ -49,6 +51,7 @@ const Header: React.FC<HeaderProps> = ({ onOpenSidebar }) => {
             <span>Help</span>
           </button>
           
+          {user && <span className="text-sm font-medium">{user.name.split(" ")[0]}</span>}
           <button onClick={handleLogout} className="btn btn-secondary px-3 py-1 text-xs flex items-center gap-1">
             <span className="material-icons text-sm">logout</span>
             <span>Logout</span>

--- a/client/src/pages/ForgotPassword.tsx
+++ b/client/src/pages/ForgotPassword.tsx
@@ -4,32 +4,40 @@ import { apiRequest } from "@/lib/queryClient";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 
-export default function Register() {
+export default function ForgotPassword() {
   const [, navigate] = useLocation();
-  const [name, setName] = useState("");
   const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
+  const [sent, setSent] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await apiRequest("POST", "/api/register", { name, email, passwordHash: password });
-      navigate("/");
+      await apiRequest("POST", "/api/forgot-password", { email });
+      setSent(true);
     } catch (err: any) {
       setError(err.message);
     }
   };
 
+  if (sent) {
+    return (
+      <div className="flex items-center justify-center min-h-screen p-4">
+        <div className="text-center space-y-4">
+          <p>Check your email for a login link.</p>
+          <Button onClick={() => navigate("/login")}>Back to login</Button>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center justify-center min-h-screen p-4">
       <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
-        <h1 className="text-2xl font-medium text-center">Create Account</h1>
+        <h1 className="text-2xl font-medium text-center">Forgot Password</h1>
         {error && <div className="text-red-600 text-sm">{error}</div>}
-        <Input placeholder="Name" value={name} onChange={e => setName(e.target.value)} />
         <Input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
-        <Input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
-        <Button type="submit" className="w-full">Register</Button>
+        <Button type="submit" className="w-full">Send Link</Button>
         <div className="text-center text-sm">
           <a href="/login" className="text-blue-600 hover:underline">Back to login</a>
         </div>
@@ -37,4 +45,3 @@ export default function Register() {
     </div>
   );
 }
-

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useLocation } from "wouter";
 import { apiRequest } from "@/lib/queryClient";
 import { Input } from "@/components/ui/input";
@@ -6,14 +6,24 @@ import { Button } from "@/components/ui/button";
 
 export default function Login() {
   const [, navigate] = useLocation();
-  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get("token");
+    if (token) {
+      apiRequest("POST", "/api/login-with-token", { token })
+        .then(() => navigate("/"))
+        .catch(err => setError(err.message));
+    }
+  }, [navigate]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await apiRequest("POST", "/api/login", { username, password });
+      await apiRequest("POST", "/api/login", { email, password });
       navigate("/");
     } catch (err: any) {
       setError(err.message);
@@ -25,10 +35,11 @@ export default function Login() {
       <form onSubmit={onSubmit} className="w-full max-w-sm space-y-4">
         <h1 className="text-2xl font-medium text-center">Login</h1>
         {error && <div className="text-red-600 text-sm">{error}</div>}
-        <Input placeholder="Username" value={username} onChange={e => setUsername(e.target.value)} />
+        <Input placeholder="Email" value={email} onChange={e => setEmail(e.target.value)} />
         <Input type="password" placeholder="Password" value={password} onChange={e => setPassword(e.target.value)} />
         <Button type="submit" className="w-full">Login</Button>
         <div className="text-center text-sm">
+          <a href="/forgot-password" className="text-blue-600 hover:underline mr-2">Forgot password?</a>
           <a href="/register" className="text-blue-600 hover:underline">Create account</a>
         </div>
       </form>

--- a/server/index.ts
+++ b/server/index.ts
@@ -94,8 +94,10 @@ app.use((req, res, next) => {
 
       await db.execute(sql`CREATE TABLE IF NOT EXISTS users (
         id SERIAL PRIMARY KEY,
-        username TEXT NOT NULL UNIQUE,
-        password_hash TEXT NOT NULL
+        name TEXT NOT NULL,
+        email TEXT NOT NULL UNIQUE,
+        password_hash TEXT NOT NULL,
+        login_token TEXT
       )`);
       
       // Check if there's any data in the database

--- a/server/pgStorage.ts
+++ b/server/pgStorage.ts
@@ -219,13 +219,26 @@ export class PgStorage implements IStorage {
     return results[0];
   }
 
-  async getUserByUsername(username: string): Promise<User | undefined> {
-    const results = await db.select().from(users).where(eq(users.username, username));
+  async getUserByEmail(email: string): Promise<User | undefined> {
+    const results = await db.select().from(users).where(eq(users.email, email));
     return results.length ? results[0] : undefined;
   }
 
   async getUserById(id: number): Promise<User | undefined> {
     const results = await db.select().from(users).where(eq(users.id, id));
     return results.length ? results[0] : undefined;
+  }
+
+  async setLoginToken(userId: number, token: string): Promise<void> {
+    await db.update(users).set({ loginToken: token }).where(eq(users.id, userId));
+  }
+
+  async getUserByLoginToken(token: string): Promise<User | undefined> {
+    const results = await db.select().from(users).where(eq(users.loginToken, token));
+    return results.length ? results[0] : undefined;
+  }
+
+  async clearLoginToken(token: string): Promise<void> {
+    await db.update(users).set({ loginToken: null }).where(eq(users.loginToken, token));
   }
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -40,8 +40,11 @@ export interface IStorage {
 
   // User operations
   createUser(user: InsertUser): Promise<User>;
-  getUserByUsername(username: string): Promise<User | undefined>;
+  getUserByEmail(email: string): Promise<User | undefined>;
   getUserById(id: number): Promise<User | undefined>;
+  setLoginToken(userId: number, token: string): Promise<void>;
+  getUserByLoginToken(token: string): Promise<User | undefined>;
+  clearLoginToken(token: string): Promise<void>;
 }
 
 export class MemStorage implements IStorage {
@@ -49,6 +52,7 @@ export class MemStorage implements IStorage {
   private jobs: Map<number, Job>;
   private payrolls: Map<number, Payroll>;
   private users: Map<number, User>;
+  private loginTokens: Map<string, number>;
   private plumberId: number;
   private jobId: number;
   private payrollId: number;
@@ -59,6 +63,7 @@ export class MemStorage implements IStorage {
     this.jobs = new Map();
     this.payrolls = new Map();
     this.users = new Map();
+    this.loginTokens = new Map();
     this.plumberId = 1;
     this.jobId = 1;
     this.payrollId = 1;
@@ -283,15 +288,29 @@ export class MemStorage implements IStorage {
     return newUser;
   }
 
-  async getUserByUsername(username: string): Promise<User | undefined> {
+  async getUserByEmail(email: string): Promise<User | undefined> {
     for (const u of this.users.values()) {
-      if (u.username === username) return u;
+      if (u.email === email) return u;
     }
     return undefined;
   }
 
   async getUserById(id: number): Promise<User | undefined> {
     return this.users.get(id);
+  }
+
+  async setLoginToken(userId: number, token: string): Promise<void> {
+    this.loginTokens.set(token, userId);
+  }
+
+  async getUserByLoginToken(token: string): Promise<User | undefined> {
+    const userId = this.loginTokens.get(token);
+    if (!userId) return undefined;
+    return this.users.get(userId);
+  }
+
+  async clearLoginToken(token: string): Promise<void> {
+    this.loginTokens.delete(token);
   }
 }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -6,12 +6,15 @@ import { sql } from "drizzle-orm";
 // User model
 export const users = pgTable("users", {
   id: serial("id").primaryKey(),
-  username: text("username").notNull().unique(),
+  name: text("name").notNull(),
+  email: text("email").notNull().unique(),
   passwordHash: text("password_hash").notNull(),
+  loginToken: text("login_token"),
 });
 
 export const insertUserSchema = createInsertSchema(users).pick({
-  username: true,
+  name: true,
+  email: true,
   passwordHash: true,
 });
 


### PR DESCRIPTION
## Summary
- store user name and email in database
- update API routes for email-based login and forgot password
- implement login token handling
- display user first name in header
- update client login/register flows
- add forgot password page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: Missing script 'test')*