### PR TITLE
Fix login/register issues and allow DB-less startup

### DIFF
--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useLocation } from "wouter";
 import { apiRequest } from "@/lib/queryClient";
 import { Input } from "@/components/ui/input";
@@ -10,15 +10,6 @@ export default function Login() {
   const [password, setPassword] = useState("");
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const token = params.get("token");
-    if (token) {
-      apiRequest("POST", "/api/login-with-token", { token })
-        .then(() => navigate("/"))
-        .catch(err => setError(err.message));
-    }
-  }, [navigate]);
 
   const onSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,15 +1,13 @@
-import { drizzle } from "drizzle-orm/node-postgres";
+import { drizzle, type NodePgDatabase } from "drizzle-orm/node-postgres";
 import { Pool } from "pg";
 import * as schema from "@shared/schema";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL environment variable is required");
+export let db: NodePgDatabase<typeof schema> | undefined;
+
+if (process.env.DATABASE_URL) {
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+  });
+  db = drizzle(pool, { schema });
 }
 
-// Create a PostgreSQL connection pool
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL,
-});
-
-// Create a Drizzle instance using the connection pool and schema
-export const db = drizzle(pool, { schema });

--- a/server/index.ts
+++ b/server/index.ts
@@ -94,8 +94,7 @@ app.use((req, res, next) => {
 
       await db.execute(sql`CREATE TABLE IF NOT EXISTS users (
         id SERIAL PRIMARY KEY,
-        name TEXT NOT NULL,
-        email TEXT NOT NULL UNIQUE,
+        username TEXT NOT NULL UNIQUE,
         password_hash TEXT NOT NULL,
         login_token TEXT
       )`);


### PR DESCRIPTION
## Summary
- allow server to start without a DATABASE_URL
- fix user table creation to use `username`
- remove unused token login code from client

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*